### PR TITLE
Upgraded symfony/validator to v2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
 		"nette/caching": "~2.2@dev",
 
 		"php": ">=5.3.2",
-		"symfony/validator": "~2.3",
-		"kdyby/annotations": "~2.0@dev",
+		"symfony/validator": "~2.5",
+		"kdyby/annotations": "~2.1@dev",
 		"kdyby/translation": "~2.0@dev"
 	},
 	"require-dev": {

--- a/src/Kdyby/Validator/DI/ValidatorExtension.php
+++ b/src/Kdyby/Validator/DI/ValidatorExtension.php
@@ -33,7 +33,8 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 	 * @var array
 	 */
 	public $defaults = array(
-		'cache' => 'Kdyby\Validator\Caching\Cache'
+		'cache' => 'Kdyby\Validator\Caching\Cache',
+		'translationDomain' => NULL,
 	);
 
 
@@ -63,16 +64,21 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 			->setFactory($cacheFactory[0]->entity, $cacheFactory[0]->arguments);
 
 		$builder->addDefinition($this->prefix('metadataFactory'))
-			->setClass('Symfony\Component\Validator\MetadataFactoryInterface')
-			->setFactory('Symfony\Component\Validator\Mapping\ClassMetadataFactory', array($this->prefix('@loader'), $this->prefix('@cache')));
+			->setClass('Symfony\Component\Validator\Mapping\Factory\MetadataFactoryInterface')
+			->setFactory('Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory')
+			->setAutowired(FALSE);
 
 		$builder->addDefinition($this->prefix('constraintValidatorFactory'))
 			->setClass('Symfony\Component\Validator\ConstraintValidatorFactoryInterface')
 			->setFactory('Kdyby\Validator\ConstraintValidatorFactory');
 
+		$builder->addDefinition($this->prefix('contextFactory'))
+			->setClass('Symfony\Component\Validator\Context\ExecutionContextFactoryInterface')
+			->setFactory('Symfony\Component\Validator\Context\ExecutionContextFactory', array('translationDomain' => $config['translationDomain']));
+
 		$builder->addDefinition($this->prefix('validator'))
-			->setClass('Symfony\Component\Validator\ValidatorInterface')
-			->setFactory('Symfony\Component\Validator\Validator');
+			->setClass('Symfony\Component\Validator\Validator\ValidatorInterface')
+			->setFactory('Symfony\Component\Validator\Validator\RecursiveValidator');
 	}
 
 
@@ -95,7 +101,10 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 			$initializers[] = '@' . $service;
 		}
 		$builder->getDefinition($this->prefix('validator'))
-			->setArguments(array('objectInitializers' => $initializers));
+			->setArguments(array(
+				'metadataFactory' => $this->prefix('@metadataFactory'),
+				'objectInitializers' => $initializers,
+			));
 	}
 
 

--- a/tests/KdybyTests/Validation/Extension.phpt
+++ b/tests/KdybyTests/Validation/Extension.phpt
@@ -45,9 +45,9 @@ class ExtensionTest extends Tester\TestCase
 	{
 		$container = $this->createContainer();
 
-		/** @var Symfony\Component\Validator\ValidatorInterface $validator */
-		$validator = $container->getByType('Symfony\Component\Validator\ValidatorInterface');
-		Tester\Assert::true($validator instanceof Symfony\Component\Validator\Validator);
+		/** @var Symfony\Component\Validator\Validator\ValidatorInterface $validator */
+		$validator = $container->getByType('Symfony\Component\Validator\Validator\ValidatorInterface');
+		Tester\Assert::true($validator instanceof Symfony\Component\Validator\Validator\RecursiveValidator);
 
 		$article = new ArticleMock();
 


### PR DESCRIPTION
I intentionally dropped support for the old Symfony 2.4 API. Since we don't have a stable version yet I think we can afford this BC break.
