### PR TITLE
ValidatorExtension: changed class for obtaining resources directory

### DIFF
--- a/src/Kdyby/Validator/DI/ValidatorExtension.php
+++ b/src/Kdyby/Validator/DI/ValidatorExtension.php
@@ -116,7 +116,7 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 	 */
 	public function getTranslationResources()
 	{
-		$validatorClass = new \ReflectionClass('Symfony\Component\Validator\Validator');
+		$validatorClass = new \ReflectionClass('Symfony\Component\Validator\Constraint');
 
 		return array(
 			dirname($validatorClass->getFileName()) . '/Resources/translations',


### PR DESCRIPTION
Validator\Validator triggers E_USER_DEPRECATED, see symfony/Validator@dcd91170a