### PR TITLE
Add support for strict e-mail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
 	"require": {
 		"nette/di": "~2.2@dev",
 		"nette/caching": "~2.2@dev",
+		"nette/utils": "~2.2@dev",
 
 		"symfony/validator": ">=2.5.3",
 		"kdyby/annotations": "~2.1@dev",

--- a/src/Kdyby/Validator/DI/ValidatorExtension.php
+++ b/src/Kdyby/Validator/DI/ValidatorExtension.php
@@ -15,6 +15,7 @@ use Kdyby\DoctrineCache\DI\Helpers;
 use Kdyby\Translation\DI\ITranslationProvider;
 use Nette;
 use Nette\DI\Compiler;
+use Nette\Utils\Validators;
 
 
 
@@ -36,6 +37,7 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 		'cache' => 'default',
 		'translationDomain' => NULL,
 		'debug' => '%debugMode%',
+		'strictEmail' => FALSE,
 	);
 
 
@@ -81,6 +83,17 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 		$builder->addDefinition($this->prefix('validator'))
 			->setClass('Symfony\Component\Validator\Validator\ValidatorInterface')
 			->setFactory('Symfony\Component\Validator\Validator\RecursiveValidator');
+
+		Validators::assertField($config, 'strictEmail', 'boolean');
+
+		$builder->addDefinition($this->prefix('constraint.email'))
+			->setClass('Symfony\Component\Validator\Constraints\EmailValidator')
+			->setArguments(array(
+				'strict' => $config['strictEmail'],
+			))
+			->addTag(self::TAG_CONSTRAINT_VALIDATOR, array(
+				'Symfony\Component\Validator\Constraints\EmailValidator',
+			));
 
 		$builder->addDefinition($this->prefix('constraint.expression'))
 			->setClass('Symfony\Component\Validator\Constraints\ExpressionValidator')

--- a/tests/KdybyTests/Validator/config/non-strict-email.neon
+++ b/tests/KdybyTests/Validator/config/non-strict-email.neon
@@ -1,0 +1,2 @@
+validator:
+	strictEmail: false

--- a/tests/KdybyTests/Validator/config/strict-email.neon
+++ b/tests/KdybyTests/Validator/config/strict-email.neon
@@ -1,0 +1,2 @@
+validator:
+	strictEmail: true


### PR DESCRIPTION
Don't merge yet. I need to test it first.

I'd like to write a test for this but I'm not sure how because [EmailValidator](https://github.com/symfony/validator/blob/master/Constraints/EmailValidator.php) doesn't have any isStrict method. Is it ok to use reflection to check the private property directly?