### PR TITLE
Make Kdyby/Annotations optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ Kdyby/Validator requires PHP 5.3.2 or higher.
 Installation
 ------------
 
-The best way to install Kdyby/Validator is using  [Composer](http://getcomposer.org/):
+The best way to install Kdyby/Validator is using [Composer](http://getcomposer.org/). It is recommended to install [Kdyby/Annotations](https://github.com/Kdyby/Annotations) as well.
 
 ```sh
-$ composer require kdyby/validator:@dev
+$ composer require kdyby/annotations
+$ composer require kdyby/validator
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,12 @@
 		"nette/utils": "~2.3@dev",
 
 		"symfony/validator": ">=2.5.3",
-		"kdyby/annotations": "~2.2@dev",
 		"kdyby/doctrine-cache": "~2.4@dev",
 		"kdyby/translation": "~2.2@dev"
 	},
 	"require-dev": {
+		"kdyby/annotations": "~2.2@dev",
+		"symfony/yaml": "^2.8|^3.0",
 		"nette/application": "~2.3@dev",
 		"nette/bootstrap": "~2.3@dev",
 		"nette/caching": "~2.3@dev",

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -7,10 +7,11 @@ This extension is here to integrate [Symfony/Validator](https://github.com/Symfo
 Installation
 -----------
 
-The best way to install Kdyby/Validator is using [Composer](http://getcomposer.org/):
+The best way to install Kdyby/Validator is using [Composer](http://getcomposer.org/). It is recommended to install [Kdyby/Annotations](https://github.com/Kdyby/Annotations) as well.
 
 ```sh
-$ composer require Kdyby/Validator:@dev
+$ composer require kdyby/annotations
+$ composer require kdyby/validator
 ```
 
 Now you need to register Kdyby/Validator, [Kdyby/Annotations](https://github.com/Kdyby/Annotations)

--- a/src/Kdyby/Validator/DI/ValidatorExtension.php
+++ b/src/Kdyby/Validator/DI/ValidatorExtension.php
@@ -51,10 +51,6 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 			->setClass('Symfony\Component\Validator\Mapping\Loader\LoaderInterface')
 			->setFactory('Symfony\Component\Validator\Mapping\Loader\LoaderChain');
 
-		$builder->addDefinition($this->prefix('annotationsLoader'))
-			->setFactory('Symfony\Component\Validator\Mapping\Loader\AnnotationLoader')
-			->addTag(self::TAG_LOADER);
-
 		$cacheService = $builder->addDefinition($this->prefix('cache'))
 			->setClass('Symfony\Component\Validator\Mapping\Cache\CacheInterface');
 
@@ -101,6 +97,12 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 				'Symfony\Component\Validator\Constraints\ExpressionValidator',
 				'validator.expression', // @link https://github.com/symfony/symfony/pull/16166
 			]);
+
+		if ($this->compiler->getExtensions('Kdyby\Annotations\DI\AnnotationsExtension')) {
+			$builder->addDefinition($this->prefix('annotationsLoader'))
+				->setFactory('Symfony\Component\Validator\Mapping\Loader\AnnotationLoader')
+				->addTag(self::TAG_LOADER);
+		}
 	}
 
 

--- a/tests/KdybyTests/Validator/config/annotations.neon
+++ b/tests/KdybyTests/Validator/config/annotations.neon
@@ -1,0 +1,2 @@
+extensions:
+	annotations: Kdyby\Annotations\DI\AnnotationsExtension

--- a/tests/KdybyTests/Validator/config/custom-loader.neon
+++ b/tests/KdybyTests/Validator/config/custom-loader.neon
@@ -1,0 +1,7 @@
+services:
+	loader:
+		class: Symfony\Component\Validator\Mapping\Loader\YamlFileLoader
+		arguments:
+			- %appDir%/Validator/config/mapping.yml
+		tags:
+			- kdyby.validator.loader

--- a/tests/KdybyTests/Validator/config/mapping.yml
+++ b/tests/KdybyTests/Validator/config/mapping.yml
@@ -1,0 +1,4 @@
+KdybyTests\ValidatorMocks\ArticleMock:
+    properties:
+        title:
+            - Email: ~

--- a/tests/KdybyTests/ValidatorMocks/ArticleMock.php
+++ b/tests/KdybyTests/ValidatorMocks/ArticleMock.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace KdybyTests\ValidatorMocks;
+
+use Nette\Object;
+use Symfony\Component\Validator\Constraints as Assert;
+
+class ArticleMock extends Object
+{
+
+	/**
+	 * @Assert\NotNull()
+	 * @var string
+	 */
+	public $title;
+
+}

--- a/tests/KdybyTests/ValidatorMocks/FooConstraint.php
+++ b/tests/KdybyTests/ValidatorMocks/FooConstraint.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace KdybyTests\ValidatorMock;
+namespace KdybyTests\ValidatorMocks;
 
 use Symfony\Component\Validator\Constraint;
 

--- a/tests/KdybyTests/ValidatorMocks/FooConstraintValidator.php
+++ b/tests/KdybyTests/ValidatorMocks/FooConstraintValidator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace KdybyTests\ValidatorMock;
+namespace KdybyTests\ValidatorMocks;
 
 use Nette\DI\Container;
 use Symfony\Component\Validator\Constraint;

--- a/tests/KdybyTests/nette-reset.neon
+++ b/tests/KdybyTests/nette-reset.neon
@@ -3,7 +3,6 @@ php:
 
 
 extensions:
-	annotations: Kdyby\Annotations\DI\AnnotationsExtension
 	translation: Kdyby\Translation\DI\TranslationExtension
 	validator: Kdyby\Validator\DI\ValidatorExtension
 
@@ -13,9 +12,9 @@ services:
 		class: Nette\Caching\Storages\MemoryStorage
 
 	-
-		class: KdybyTests\ValidatorMock\FooConstraintValidator
+		class: KdybyTests\ValidatorMocks\FooConstraintValidator
 		tags:
-			kdyby.validator.constraintValidator: KdybyTests\ValidatorMock\FooConstraintValidator
+			kdyby.validator.constraintValidator: KdybyTests\ValidatorMocks\FooConstraintValidator
 
 http:
 	frames: null


### PR DESCRIPTION
Same as Doctrine, Validator can get the configuration by other means than annotations so the dependency should be optional.

Not that I need it personally but still a good idea imo.