### PR TITLE
Remove need to duplicate class name in service definition

### DIFF
--- a/src/Kdyby/Validator/DI/ValidatorExtension.php
+++ b/src/Kdyby/Validator/DI/ValidatorExtension.php
@@ -91,14 +91,11 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 			->setArguments([
 				'strict' => $config['strictEmail'],
 			])
-			->addTag(self::TAG_CONSTRAINT_VALIDATOR, [
-				'Symfony\Component\Validator\Constraints\EmailValidator',
-			]);
+			->addTag(self::TAG_CONSTRAINT_VALIDATOR);
 
 		$builder->addDefinition($this->prefix('constraint.expression'))
 			->setClass('Symfony\Component\Validator\Constraints\ExpressionValidator')
 			->addTag(self::TAG_CONSTRAINT_VALIDATOR, [
-				'Symfony\Component\Validator\Constraints\ExpressionValidator',
 				'validator.expression', // @link https://github.com/symfony/symfony/pull/16166
 			]);
 	}
@@ -133,6 +130,7 @@ class ValidatorExtension extends Nette\DI\CompilerExtension implements ITranslat
 			foreach ((array) $attributes as $name) {
 				$validators[$name] = (string) $service;
 			}
+			$validators[(new \ReflectionClass($builder->getDefinition($service)->getClass()))->getName()] = (string) $service;
 		}
 		$builder->getDefinition($this->prefix('constraintValidatorFactory'))
 			->setArguments([


### PR DESCRIPTION
This is the magic needed to simplify validator service definition.

```yml
# before
phoneValidator:
        class: Model\Validation\Validator\PhoneValidator
        tags:
            kdyby.validator.constraintValidator: Model\Validation\Validator\PhoneValidator

#after
phoneValidator:
        class: Model\Validation\Validator\PhoneValidator
        tags:
            - kdyby.validator.constraintValidator
```

I don't really care personally though.

Thoughts? cc @janedbal, @Majkl578

(WIP because we can't merge it without a test obviously.)