### PR TITLE
prevent symfony/validator v5 from installing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"nette/di": "~2.4@dev",
 		"nette/utils": "~2.4@dev",
 
-		"symfony/validator": ">=4.1.0",
+		"symfony/validator": ">=4.1.0 <4.4",
 		"kdyby/doctrine-cache": "~2.4@dev",
 		"kdyby/translation": "~2.2@dev"
 	},


### PR DESCRIPTION
Version 5 was released 5 days ago (https://github.com/symfony/validator/releases) and breaks this package with error `Nette\DI\ServiceCreationException: Class Symfony\Component\Validator\Mapping\Cache\DoctrineCache used in service 'validator.cache' not found.`

Thanks for merge and release of new version.